### PR TITLE
Lowercase changed to uppercase in Level name translation

### DIFF
--- a/edu/translations/tutor-pl_PL.po
+++ b/edu/translations/tutor-pl_PL.po
@@ -2421,7 +2421,7 @@ msgstr "Ekspert"
 
 #: classes/Utils.php:3822
 msgid "Intermediate"
-msgstr "średnio zaawansowany"
+msgstr "Średnio zaawansowany"
 
 #: classes/Utils.php:3821
 msgid "Beginner"


### PR DESCRIPTION
Polish translation of intermediate level "średnio zaawansowany" - would be nice to start with uppercase Ś letter. Other levels names also start with uppercase.